### PR TITLE
Remove error giving line. Animations work fine even after removing th…

### DIFF
--- a/AnimationDemo/TransformViewController.swift
+++ b/AnimationDemo/TransformViewController.swift
@@ -33,8 +33,6 @@ class TransformViewController: UIViewController {
 	
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
-		
-		state = (state)
 	}
 	
 	func setState(_ state: State, animated: Bool) {


### PR DESCRIPTION
Line number 37 in `TransformViewController.swift` was giving error `Assigning property to itself`. After removing this line, project build is succeeding and animations are working as expected.